### PR TITLE
Update VITE_API_BASE_URL to production endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,4 @@ VITE_APP_API_BASE_URL=https://resqhub-be.onrender.com
 VITE_APP_API_TIMEOUT=10000
 VITE_APP_ENABLE_API_LOGGING=true
 VITE_APP_FRONTEND_VERSION=1.0.0
-VITE_API_BASE_URL=http://localhost:5173
+VITE_API_BASE_URL=https://resqhub-six.vercel.app


### PR DESCRIPTION
Change the VITE_API_BASE_URL to point to the production endpoint instead of the local development server.